### PR TITLE
Wrap audio and anchor in span

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -60,7 +60,8 @@ class Hooks {
 
 			$vol = $args['vol'] ?? '1.0';
 
-			$output = '<audio';
+			$output = '<span>';
+			$output .= '<audio';
 			$output .= ' hidden';
 			$output .= ' class="ext-audiobutton"';
 			$output .= ' data-volume="' . $vol . '">';
@@ -71,6 +72,7 @@ class Hooks {
 			$output .= ' class="ext-audiobutton"';
 			$output .= ' data-state="play"';
 			$output .= ' title="Play/Pause">▶️</a>';
+			$output .= '</span>';
 		} else {
 			$output = '<a class="ext-audiobutton" data-state="error" title="File not found"></a>';
 		}


### PR DESCRIPTION
Fix #6

Tested it on a local wiki with the following wikitext:

```
<ab>Rain.mp3</ab>

[[File:Image.png|50px|left]]<ab>Rain.mp3</ab>

test test <ab>Rain.mp3</ab> test test

```

all three `ab`s work as expected.