### PR TITLE
Update Hooks.php to include preload arg

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -59,11 +59,13 @@ class Hooks {
 			$mimetype = $file->getMimeType();
 
 			$vol = $args['vol'] ?? '1.0';
+			$preload = $args['preload'] ?? 'auto';
 
 			$output = '<span>';
 			$output .= '<audio';
 			$output .= ' hidden';
 			$output .= ' class="ext-audiobutton"';
+			$output .= ' preload="' . $preload . '"';
 			$output .= ' data-volume="' . $vol . '">';
 			$output .= '<source src="' . $url . '" type="' . $mimetype . '">';
 			$output .= '<a href="' . $url . '">Link</a>';

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -59,7 +59,7 @@ class Hooks {
 			$mimetype = $file->getMimeType();
 
 			$vol = $args['vol'] ?? '1.0';
-			$preload = $args['preload'] ?? 'auto';
+			$preload = $args['preload'] ?? 'metadata';
 
 			$output = '<span>';
 			$output .= '<audio';


### PR DESCRIPTION
Add preload option to work around WebMediaPlayer limit on Chromium for pages containing more than 1000 objects. Ref: https://bugs.chromium.org/p/chromium/issues/detail?id=1144736#c27