### PR TITLE
Make extension MediaWiki 1.39+ compatible, make extension translatable

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -31,7 +31,9 @@
 			"styles": [
 				"ext.audioButton.less"
 			],
-			"messages": [],
+			"messages": [
+				"audiobutton-error-not-supported"
+			],
 			"dependencies": [],
 			"targets": [
 				"desktop",

--- a/extension.json
+++ b/extension.json
@@ -9,7 +9,7 @@
 	"license-name": "MIT",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.29.0"
+		"MediaWiki": ">= 1.34.0"
 	},
 	"AutoloadClasses": {
 		"MediaWiki\\Extension\\AudioButton\\Hooks": "src/Hooks.php",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,5 +4,10 @@
 			"Nils Enevoldsen"
 		]
 	},
-	"audiobutton-desc": "Creates a one-button play/pause toggle for an uploaded audio file"
+	"audiobutton-desc": "Creates a one-button play/pause toggle for an uploaded audio file",
+
+	"audiobutton-play-pause": "Play/Pause",
+	"audiobutton-link": "Link",
+	"audiobutton-error-not-found": "File not found",
+	"audiobutton-error-not-supported": "Audio type not supported"
 }

--- a/resources/ext.audioButton.js
+++ b/resources/ext.audioButton.js
@@ -2,7 +2,7 @@
 	function deactivate( button ) {
 		var audio = button.previousElementSibling;
 		button.dataset.state = 'error';
-		button.title = 'Audio type not supported';
+		button.title = mw.message( 'audiobutton-error-not-supported' ).text();
 		button.href = audio.firstElementChild.src;
 		audio.remove();
 	}

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -79,7 +79,8 @@ class Hooks {
 			$output .= '</span>';
 			$parser->getOutput()->addImage( $file->getTitle()->getDBkey(), $file->getTimestamp(), $file->getSha1() );
 		} else {
-			$output = '<a class="ext-audiobutton" data-state="error" title="' . wfMessage( 'audiobutton-error-not-found' )->text() . '"></a>';
+			$output = '<a class="ext-audiobutton" data-state="error" title="' 
+				. wfMessage( 'audiobutton-error-not-found' )->text() . '"></a>';
 		}
 
 		return $output;

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -19,6 +19,8 @@
 
 namespace MediaWiki\Extension\AudioButton;
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Hooks for AudioButton extension
  */
@@ -52,7 +54,7 @@ class Hooks {
 			return '';
 		}
 
-		$file = wfFindFile( $input );
+		$file = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $input );
 
 		if ( $file ) {
 			$url = $file->getFullURL();

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -70,16 +70,16 @@ class Hooks {
 			$output .= ' preload="' . $preload . '"';
 			$output .= ' data-volume="' . $vol . '">';
 			$output .= '<source src="' . $url . '" type="' . $mimetype . '">';
-			$output .= '<a href="' . $url . '">Link</a>';
+			$output .= '<a href="' . $url . '">' . wfMessage( 'audiobutton-link' )->text() . '</a>';
 			$output .= '</audio>';
 			$output .= '<a';
 			$output .= ' class="ext-audiobutton"';
 			$output .= ' data-state="play"';
-			$output .= ' title="Play/Pause">▶️</a>';
+			$output .= ' title="' . wfMessage( 'audiobutton-play-pause' )->text() . '">▶️</a>';
 			$output .= '</span>';
 			$parser->getOutput()->addImage( $file->getTitle()->getDBkey(), $file->getTimestamp(), $file->getSha1() );
 		} else {
-			$output = '<a class="ext-audiobutton" data-state="error" title="File not found"></a>';
+			$output = '<a class="ext-audiobutton" data-state="error" title="' . wfMessage( 'audiobutton-error-not-found' )->text() . '"></a>';
 		}
 
 		return $output;

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -79,7 +79,7 @@ class Hooks {
 			$output .= '</span>';
 			$parser->getOutput()->addImage( $file->getTitle()->getDBkey(), $file->getTimestamp(), $file->getSha1() );
 		} else {
-			$output = '<a class="ext-audiobutton" data-state="error" title="' 
+			$output = '<a class="ext-audiobutton" data-state="error" title="'
 				. wfMessage( 'audiobutton-error-not-found' )->text() . '"></a>';
 		}
 


### PR DESCRIPTION
This removes usage of the removed global function `wfFindFile()`. Since the new way of finding a file is only existent since MediaWiki 1.34 I've upped the MediaWiki version requirement, gicen even 1.35 is now end of life this should still be plenty though.

This also moves all the localisation strings to the en.json file
