### PR TITLE
Make extension compatible with MediaWiki >= 1.41

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -47,7 +47,7 @@ class Hooks {
 	 * @return string
 	 */
 	public static function renderAudioButton( $input, array $args, $parser, $frame ) {
-		$parser->getOutput()->addModules( 'ext.audioButton' );
+		$parser->getOutput()->addModules( [ 'ext.audioButton' ] );
 		$input = $parser->recursiveTagParse( $input, $frame );
 
 		if ( !$input ) {


### PR DESCRIPTION
Since MediaWiki 1.41 `ParserOutput::addModules()` requires the first argument to be an array, see https://github.com/wikimedia/mediawiki/commit/2aad6af983a3cda68c71c32e85b9be27e7ef2a07

This is fully backwards compatible to any reasonably supported MediaWiki version including old LTS (1.39) as the old behaviour was deprecated since MediaWiki 1.38