### PR TITLE
Fix multiline not able to find file

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -48,7 +48,7 @@ class Hooks {
 	 */
 	public static function renderAudioButton( $input, array $args, $parser, $frame ) {
 		$parser->getOutput()->addModules( [ 'ext.audioButton' ] );
-		$input = $parser->recursiveTagParse( $input, $frame );
+		$input = trim( $parser->recursiveTagParse( $input, $frame ) );
 
 		if ( !$input ) {
 			return '';


### PR DESCRIPTION
Having any newlines introduces `\n` so the parser gets fed the wrong file name:
```
<sm2>
File.mp3
</sm2>
```

-> `\nFile.mp3\n`

Simply trimming it fixes this (and any potential whitespace for that matter, though i'm fairly sure mw already handles that internally)